### PR TITLE
Make authentication required by default on all routes

### DIFF
--- a/.dev.vars
+++ b/.dev.vars
@@ -1,3 +1,2 @@
 ENVIRONMENT = 'development'
 TURBO_TOKEN = 'SECRET'
-REQUIRE_AUTH = true

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,7 +4,6 @@ import { app } from './routes';
 export type Env = {
   ENVIRONMENT: 'development' | 'production';
   R2_STORE: R2Bucket;
-  REQUIRE_AUTH: boolean;
   TURBO_TOKEN: string;
   BUCKET_OBJECT_EXPIRATION_HOURS: number;
 };

--- a/src/routes/commandCentral.test.ts
+++ b/src/routes/commandCentral.test.ts
@@ -51,23 +51,4 @@ describe('Command central /delete-old-cache route', () => {
     expect(response.status).toBe(401);
     expect(deleteOldCacheMock).not.toHaveBeenCalled();
   });
-
-  test('should invoke the deleteOldCache method if auth is not required', async () => {
-    const request = new Request('http://localhost/commandCentral/delete-expired-objects', {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-      },
-    });
-    const response = await app.fetch(
-      request,
-      {
-        ...workerEnv,
-        REQUIRE_AUTH: false,
-      },
-      ctx
-    );
-    expect(response.status).toBe(200);
-    expect(deleteOldCacheMock).toHaveBeenCalledOnce();
-  });
 });

--- a/src/routes/commandCentral.ts
+++ b/src/routes/commandCentral.ts
@@ -6,12 +6,8 @@ import { deleteOldCache } from '../crons/deleteOldCache';
 export const commandCentralRouter = new Hono<{ Bindings: Env }>();
 
 commandCentralRouter.use('*', async (c, next) => {
-  if (c.env.REQUIRE_AUTH) {
-    const middleware = bearerAuth({ token: c.env.TURBO_TOKEN });
-    await middleware(c, next);
-  } else {
-    await next();
-  }
+  const middleware = bearerAuth({ token: c.env.TURBO_TOKEN });
+  await middleware(c, next);
 });
 
 commandCentralRouter.post('/delete-expired-objects', async (c) => {

--- a/src/routes/v8/artifacts.auth.test.ts
+++ b/src/routes/v8/artifacts.auth.test.ts
@@ -25,15 +25,12 @@ describe('Authentication module for artifacts API', () => {
     return request;
   }
 
-  describe('should require authentication when REQUIRE_AUTH is true', () => {
+  describe('should require authentication when uploading artifacts', () => {
     let workerEnv: Env;
     let ctx: ExecutionContext;
 
     beforeEach(() => {
-      workerEnv = {
-        ...getMiniflareBindings<Env>(),
-        REQUIRE_AUTH: true,
-      };
+      workerEnv = getMiniflareBindings<Env>();
       ctx = new ExecutionContext();
     });
 
@@ -44,36 +41,6 @@ describe('Authentication module for artifacts API', () => {
       );
       const res = await app.fetch(request, workerEnv, ctx);
       expect(res.status).toBe(401);
-    });
-
-    test('should return 200 when Authorization header is present', async () => {
-      const request = createArtifactGetRequest(
-        `http://localhost/v8/artifacts/${artifactId}?teamId=${teamId}`
-      );
-      const res = await app.fetch(request, workerEnv, ctx);
-      expect(res.status).toBe(200);
-    });
-  });
-
-  describe('should not require authentication when REQUIRE_AUTH is false', () => {
-    let workerEnv: Env;
-    let ctx: ExecutionContext;
-
-    beforeEach(() => {
-      workerEnv = {
-        ...getMiniflareBindings<Env>(),
-        REQUIRE_AUTH: false,
-      };
-      ctx = new ExecutionContext();
-    });
-
-    test('should return 200 when Authorization header is missing', async () => {
-      const request = createArtifactGetRequest(
-        `http://localhost/v8/artifacts/${artifactId}?teamId=${teamId}`,
-        false
-      );
-      const res = await app.fetch(request, workerEnv, ctx);
-      expect(res.status).toBe(200);
     });
 
     test('should return 200 when Authorization header is present', async () => {

--- a/src/routes/v8/index.ts
+++ b/src/routes/v8/index.ts
@@ -6,11 +6,7 @@ import { artifactRouter } from './artifacts';
 export const v8App = new Hono<{ Bindings: Env }>();
 
 v8App.use('/artifacts/*', async (c, next) => {
-  if (c.env.REQUIRE_AUTH) {
-    const middleware = bearerAuth({ token: c.env.TURBO_TOKEN });
-    await middleware(c, next);
-  } else {
-    await next();
-  }
+  const middleware = bearerAuth({ token: c.env.TURBO_TOKEN });
+  await middleware(c, next);
 });
 v8App.route('/artifacts', artifactRouter);

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -5,10 +5,8 @@ usage_model = 'bundled'
 
 [vars]
 ENVIRONMENT = 'production'
-# When enabling authentication, the following secrets are needed
 # - TURBO_TOKEN (must a valid Bearer auth token)
 # Run `echo <VALUE> | wrangler secret put <NAME>` for each of these
-REQUIRE_AUTH = true
 BUCKET_OBJECT_EXPIRATION_HOURS = 720 # 30 days
 
 [[r2_buckets]]


### PR DESCRIPTION
# Description

This project has had the option to disable bearer authentication on the server using the `REQUIRE_AUTH` config provided in wrangler.toml.

I am choosing to remove the optional flag and requiring authentication for these reasons
- Not having authentication realistically never worked with turborepo as the turbo command itself will not recognise remote caching as enabled if no API token is provided via the `TURBO_TOKEN` environment variable.
- Requiring authentication as a standard seems much better. If a user of this service wants their authentication to be public, they can just expose the auth token.

# How Has This Been Tested?

- Unit tests have been updated accordingly
- Tested locally by pointing a turborepo repository to the local server
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### Summary by CodeRabbit

**Refactor:**
- Removed the `REQUIRE_AUTH` global variable from the codebase.
- Simplified authentication middleware application by removing conditional checks for `REQUIRE_AUTH`.
- Updated test cases to reflect changes in authentication requirements.

> 🎉🐇
> 
> No more auth flags, no more fuss,
> 
> Cleaner code, thanks to us!
> 
> Middleware applied, no condition,
> 
> Celebrate this neat transition! 🥳🎉
<!-- end of auto-generated comment: release notes by coderabbit.ai -->