### PR TITLE
Add routes for latency testing

### DIFF
--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -40,4 +40,24 @@ describe('rest-api worker', () => {
     const res = await app.fetch(request, workerEnv, ctx);
     expect(await res.text()).toBe('pong');
   });
+
+  it('should respond to the latency-test route via invoking the app', async () => {
+    const request = new Request('http://localhost/latency-test', {
+      method: 'POST',
+      body: JSON.stringify({}),
+    });
+    const res = await app.fetch(request, workerEnv, ctx);
+    expect(await res.json()).toEqual({
+      content: '🎉😄😇🎉😄😇🎉😄😇🎉😄😇',
+    });
+  });
+
+  it('should respond to the throw-exception route via invoking the app', async () => {
+    const request = new Request('http://localhost/throw-exception');
+    const res = await app.fetch(request, workerEnv, ctx);
+    expect(res.status).toBe(500);
+    expect(await res.json()).toEqual({
+      error: 'Expected error',
+    });
+  });
 });

--- a/src/routes/index.ts
+++ b/src/routes/index.ts
@@ -1,4 +1,5 @@
 import { Hono } from 'hono';
+import { HTTPException } from 'hono/http-exception';
 import { cors } from 'hono/cors';
 import { Env } from '..';
 import { v8App } from './v8';
@@ -6,10 +7,38 @@ import { commandCentralRouter } from './commandCentral';
 
 export const app = new Hono<{ Bindings: Env }>();
 
+app.onError((err, c) => {
+  if (err instanceof HTTPException) {
+    return err.getResponse();
+  }
+  return c.json({ error: err.message }, 500);
+});
+
 app.use('*', cors());
 
+// minimal health check routes
 app.get('/ping', (c) => c.text('pong'));
-app.post('/latency-test', (c) => c.json({ timestamp: Date.now().toString() }));
+app.get('/throw-exception', () => {
+  throw new Error('Expected error');
+});
+
+// simulate latency for global performance testing
+app.post('/latency-test', async (c) => {
+  const artifactId = 'UNIQUE-artifactId-' + Math.random();
+  const artifactTag = 'UNIQUE-artifactTag-' + Math.random();
+  const teamId = 'UNIQUE-teamId-' + Math.random();
+  const artifactContent = '🎉😄😇🎉😄😇🎉😄😇🎉😄😇';
+  // store and get back content to simulate latency
+  await c.env.R2_STORE.put(`${teamId}/existing-${artifactId}`, artifactContent, {
+    customMetadata: { artifactTag },
+  });
+  const r2Object = await c.env.R2_STORE.get(`${teamId}/existing-${artifactId}`);
+  if (!r2Object) {
+    throw new Error('r2Object not found');
+  }
+  const r2Text = await r2Object.text();
+  return c.json({ content: r2Text });
+});
 
 app.route('/v8', v8App);
 app.route('/commandCentral', commandCentralRouter);


### PR DESCRIPTION
Create a new route called `/latency-test` to use in global performance testing
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### Summary by CodeRabbit

**New Features:**
- Added a new route `/throw-exception` to simulate an error scenario for testing purposes.
- Introduced a new route `/latency-test` to simulate latency by interacting with a storage service.

**Improvements:**
- Implemented global error handling for exceptions within the application.

**Tests:**
- Added two new test cases to validate the behavior of the newly introduced routes.

> 🎉 Hoppity hop, code doesn't stop,
> New routes are here, making errors clear. 🐾
> Latency test, put to rest,
> With each new feature, we're at our best! 🥕🚀
<!-- end of auto-generated comment: release notes by coderabbit.ai -->