### PR TITLE
Refactor performance route

### DIFF
--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -6,7 +6,7 @@ import { Env } from '.';
 
 const describe = setupMiniflareIsolatedStorage();
 
-describe('rest-api worker', () => {
+describe('remote-cache worker', () => {
   let worker: UnstableDevWorker;
   let workerEnv: Env;
   let ctx: ExecutionContext;
@@ -39,17 +39,6 @@ describe('rest-api worker', () => {
     const request = new Request('http://localhost/ping');
     const res = await app.fetch(request, workerEnv, ctx);
     expect(await res.text()).toBe('pong');
-  });
-
-  it('should respond to the latency-test route via invoking the app', async () => {
-    const request = new Request('http://localhost/latency-test', {
-      method: 'POST',
-      body: JSON.stringify({}),
-    });
-    const res = await app.fetch(request, workerEnv, ctx);
-    expect(await res.json()).toEqual({
-      content: '🎉😄😇🎉😄😇🎉😄😇🎉😄😇',
-    });
   });
 
   it('should respond to the throw-exception route via invoking the app', async () => {

--- a/src/routes/index.ts
+++ b/src/routes/index.ts
@@ -4,6 +4,7 @@ import { cors } from 'hono/cors';
 import { Env } from '..';
 import { v8App } from './v8';
 import { commandCentralRouter } from './commandCentral';
+import { performanceTestingRouter } from './performanceTesting';
 
 export const app = new Hono<{ Bindings: Env }>();
 
@@ -22,23 +23,6 @@ app.get('/throw-exception', () => {
   throw new Error('Expected error');
 });
 
-// simulate latency for global performance testing
-app.post('/latency-test', async (c) => {
-  const artifactId = 'UNIQUE-artifactId-' + Math.random();
-  const artifactTag = 'UNIQUE-artifactTag-' + Math.random();
-  const teamId = 'arishi-performance-testing';
-  const artifactContent = '🎉😄😇🎉😄😇🎉😄😇🎉😄😇';
-  // store and get back content to simulate latency
-  await c.env.R2_STORE.put(`${teamId}/existing-${artifactId}`, artifactContent, {
-    customMetadata: { artifactTag },
-  });
-  const r2Object = await c.env.R2_STORE.get(`${teamId}/existing-${artifactId}`);
-  if (!r2Object) {
-    throw new Error('r2Object not found');
-  }
-  const r2Text = await r2Object.text();
-  return c.json({ content: r2Text });
-});
-
 app.route('/v8', v8App);
 app.route('/commandCentral', commandCentralRouter);
+app.route('/performance-testing', performanceTestingRouter);

--- a/src/routes/performanceTesting.test.ts
+++ b/src/routes/performanceTesting.test.ts
@@ -1,0 +1,26 @@
+import { expect, it, beforeEach } from 'vitest';
+import { app } from '.';
+import { Env } from '..';
+
+const describe = setupMiniflareIsolatedStorage();
+
+describe('Performance Testing Routes', () => {
+  let workerEnv: Env;
+  let ctx: ExecutionContext;
+
+  beforeEach(() => {
+    workerEnv = getMiniflareBindings();
+    ctx = new ExecutionContext();
+  });
+
+  it('should respond to the r2-round-trip route via invoking the app', async () => {
+    const request = new Request('http://localhost/performance-testing/r2-round-trip', {
+      method: 'POST',
+    });
+    const res = await app.fetch(request, workerEnv, ctx);
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({
+      content: '🎉😄😇🎉😄😇🎉😄😇🎉😄😇',
+    });
+  });
+});

--- a/src/routes/performanceTesting.ts
+++ b/src/routes/performanceTesting.ts
@@ -1,0 +1,21 @@
+import { Hono } from 'hono';
+import { Env } from '..';
+
+export const performanceTestingRouter = new Hono<{ Bindings: Env }>();
+
+performanceTestingRouter.post('/r2-round-trip', async (c) => {
+  const artifactId = 'UNIQUE-artifactId-' + Math.random();
+  const artifactTag = 'UNIQUE-artifactTag-' + Math.random();
+  const teamId = 'arishi-performance-testing';
+  const artifactContent = '🎉😄😇🎉😄😇🎉😄😇🎉😄😇';
+  // store and get back content to simulate latency
+  await c.env.R2_STORE.put(`${teamId}/existing-${artifactId}`, artifactContent, {
+    customMetadata: { artifactTag },
+  });
+  const r2Object = await c.env.R2_STORE.get(`${teamId}/existing-${artifactId}`);
+  if (!r2Object) {
+    throw new Error('r2Object not found');
+  }
+  const r2Text = await r2Object.text();
+  return c.json({ content: r2Text });
+});


### PR DESCRIPTION

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### Summary by CodeRabbit

**New Feature:**
- Added a new route `/performance-testing/r2-round-trip` for performance testing. This route generates unique IDs and tags, stores content in a simulated latency environment, retrieves the stored content, and returns it as a JSON response.

**Refactor:**
- Removed global performance testing simulation code.
- Updated test suite description from 'rest-api worker' to 'remote-cache worker'.
- Removed test case for 'latency-test' route.

**Test:**
- Added a new test case for the `/performance-testing/r2-round-trip` route.

> 🎉🐇
> 
> Hoppity hop, with joy we leap,
> For the code's depth has grown deep.
> New routes to test, old ones retire,
> Our codebase, it does inspire.
> With each PR, our progress chart,
> In this coding art, we play our part! 🚀🎈

<!-- end of auto-generated comment: release notes by coderabbit.ai -->