### PR TITLE
(feat): Add internal route to count the number of objects in a bucket

### DIFF
--- a/src/routes/internal.ts
+++ b/src/routes/internal.ts
@@ -48,3 +48,18 @@ internalRouter.post(
     return c.json({ success: true });
   }
 );
+
+internalRouter.get('/count-objects', async (c) => {
+  let truncated = false;
+  let cursor: string | undefined;
+  let list: R2Objects;
+  let count = 0;
+  do {
+    list = await c.env.R2_STORE.list({ limit: 999, cursor });
+    truncated = list.truncated;
+    cursor = list.truncated ? list.cursor : undefined;
+    count += list.objects.length;
+  } while (truncated);
+
+  return c.json({ count });
+});


### PR DESCRIPTION

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### Summary by CodeRabbit

**New Feature:**
- Added a new endpoint `/internal/count-objects` to count the number of objects in the R2 bucket.
- The endpoint returns the total count as a JSON response.

**Test:**
- Added test cases for the new endpoint, verifying correct counts and proper handling of missing authentication tokens.

> 🎉🐇
> 
> "In the land of code, where logic intertwines,
> A new feature blooms, as bright as sunshine. 🌞
> Counting objects fast, in the R2's nest,
> With tests to ensure, it's performing its best. 🚀
> Rejoice, dear friends, for our code has grown,
> Another milestone, together we've sown. 🌱"

<!-- end of auto-generated comment: release notes by coderabbit.ai -->