### PR TITLE
Fix deletion cron throwing exception with zero keys

### DIFF
--- a/src/crons/deleteOldCache.test.ts
+++ b/src/crons/deleteOldCache.test.ts
@@ -73,4 +73,13 @@ describe('R2 delete cron', () => {
     const artifacts = await workerEnv.R2_STORE.list();
     expect(artifacts.objects.length).toEqual(0);
   });
+
+  test('should not call R2Bucket.delete with no keys', async () => {
+    const spy = vi.spyOn(workerEnv.R2_STORE, 'delete');
+    isDateOlderThanMock.mockReturnValue(false); // Make sure no objects are marked for deletion
+
+    await deleteOldCache(workerEnv);
+
+    expect(spy).not.toHaveBeenCalledWith([]);
+  });
 });

--- a/src/crons/deleteOldCache.ts
+++ b/src/crons/deleteOldCache.ts
@@ -38,7 +38,11 @@ export async function deleteOldCache(env: Env): Promise<void> {
         keysForDeletion.add(object.key);
       }
     }
-    keysMarkedForDeletion.push(keysForDeletion);
+
+    // Only append if there's keys to delete from this page
+    if (keysForDeletion.keys.length > 0) {
+      keysMarkedForDeletion.push(keysForDeletion);
+    }
   } while (truncated);
   for (const keysForDeletion of keysMarkedForDeletion) {
     await env.R2_STORE.delete(keysForDeletion.keys);


### PR DESCRIPTION
# Description

Don't call R2Bucket#delete with an empty array of keys. This is another odd case that works fine on Miniflare, but fails when actually ran on Cloudflare.

Fixes #55 

# How Has This Been Tested?

Created new test to ensure `R2Bucket#delete` is never called with `[]`. Test fails on current version of the repo, but passes on this PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### Summary by CodeRabbit

- Test: Added a new test case in the `R2 delete cron` suite to ensure that the `deleteOldCache` function does not call `R2Bucket.delete` when there are no keys marked for deletion.
- Refactor: Optimized the `deleteOldCache` function by adding a conditional check to prevent unnecessary additions to the list of keys marked for deletion when there are no keys to delete. This improves the efficiency of the cache cleanup process.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->