### PR TITLE
(feat): Setup cache for GET artifact route

### DIFF
--- a/src/routes/v8/artifacts.test.ts
+++ b/src/routes/v8/artifacts.test.ts
@@ -94,6 +94,15 @@ describe('v8 Artifacts API', () => {
       expect(res.headers.get('Content-Type')).toBe('application/octet-stream');
       expect(res.headers.get('x-artifact-tag')).toBe(artifactTag);
     });
+
+    test('should return cache headers on every request', async () => {
+      const request = createArtifactGetRequest(
+        `http://localhost/v8/artifacts/existing-${artifactId}?teamId=${teamId}`
+      );
+      const res = await app.fetch(request, workerEnv, ctx);
+      expect(res.status).toBe(200);
+      expect(res.headers.get('Cache-Control')).toBe('max-age=86400, stale-while-revalidate=3600');
+    });
   });
 
   describe('PUT artifact endpoint', () => {

--- a/src/routes/v8/artifacts.ts
+++ b/src/routes/v8/artifacts.ts
@@ -1,5 +1,6 @@
 import { zValidator } from '@hono/zod-validator';
 import { Hono } from 'hono';
+import { cache } from 'hono/cache';
 import { z } from 'zod';
 import { Env } from '../..';
 
@@ -42,6 +43,11 @@ artifactRouter.put(
 // Hono router .get() method captures both GET and HEAD requests
 artifactRouter.get(
   '/:artifactId/:teamId?',
+  cache({
+    cacheName: 'r2-artifacts',
+    wait: false,
+    cacheControl: 'max-age=86400, stale-while-revalidate=3600',
+  }),
   zValidator('param', z.object({ artifactId: z.string() })),
   zValidator('query', z.object({ teamId: z.string().optional(), slug: z.string().optional() })),
   async (c) => {


### PR DESCRIPTION
Confirmed that the cache works with a custom domain - 
![Screenshot 2023-09-01 at 6 17 23 pm](https://github.com/AdiRishi/turborepo-remote-cache-cloudflare/assets/8351234/bd851900-abed-4eb1-aacc-d185254081bd)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### Summary by CodeRabbit

- New Feature: Added caching functionality to the v8 Artifacts API. This feature will improve response times and reduce server load by storing frequently accessed data in cache.
- Test: Added a new test case to ensure that the correct cache headers are being sent in the response from the server. This helps maintain the reliability of our caching system.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->