### PR TITLE
(fix): Accept newer versions of CF_API_TOKEN/ACCOUNT_ID in deploy.yml

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -21,8 +21,8 @@ jobs:
         env:
           TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
         with:
-          accountId: ${{ secrets.CF_ACCOUNT_ID }}
-          apiToken: ${{ secrets.CF_API_TOKEN }}
+          accountId: ${{ secrets.CF_ACCOUNT_ID || secrets.CLOUDFLARE_ACCOUNT_ID }}
+          apiToken: ${{ secrets.CF_API_TOKEN || secrets.CLOUDFLARE_API_TOKEN }}
           wranglerVersion: 'latest'
           preCommands: |
             echo "*** post commands ***"


### PR DESCRIPTION
Deploy.yml currently only accepted the deprecated versions of the api token and account id secrets.
This PR fixes that.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### Summary by CodeRabbit

- Chore: Updated GitHub Actions workflow in `deploy.yml`. The environment variables `accountId` and `apiToken` are now more flexible, allowing for the use of either the original secrets or new secrets (`CLOUDFLARE_ACCOUNT_ID` and `CLOUDFLARE_API_TOKEN`). This change enhances the flexibility of our deployment process by accommodating different sets of secrets depending on their availability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->