### PR TITLE
(fix): Use a default value for secrets.TURBO_TOKEN to prevent one-click  deployment failure

### DIFF
--- a/.changeset/five-windows-enjoy.md
+++ b/.changeset/five-windows-enjoy.md
@@ -1,0 +1,5 @@
+---
+'turborepo-remote-cache-cf': patch
+---
+
+Use a default value for secrets.TURBO_TOKEN to prevent one-click deployment (fork) failures

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Deploy
         uses: cloudflare/wrangler-action@v3
         env:
-          TURBO_TOKEN: ${{ secrets.TURBO_TOKEN }}
+          TURBO_TOKEN: ${{ secrets.TURBO_TOKEN || 'SECRET' }}
         with:
           accountId: ${{ secrets.CF_ACCOUNT_ID || secrets.CLOUDFLARE_ACCOUNT_ID }}
           apiToken: ${{ secrets.CF_API_TOKEN || secrets.CLOUDFLARE_API_TOKEN }}


### PR DESCRIPTION
Related to #247 

I keep seeing failures on one-click deployment (forks) like this
![Screenshot 2024-01-23 at 1 18 47 pm](https://github.com/AdiRishi/turborepo-remote-cache-cloudflare/assets/8351234/215a417b-09f5-4568-91ab-bbe082f32687)

The hope is to create an initial successful deployment, allowing users to fix the turbo token once a successful deployment goes through.