### PR TITLE
fix(ci): point deploy workflow at self-hosted turbo cache

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -9,6 +9,10 @@ jobs:
   build-and-deploy:
     runs-on: ubuntu-latest
     name: Build & Deploy
+    env:
+      TURBO_TOKEN: ${{ secrets.TURBO_TOKEN || 'SECRET' }}
+      TURBO_TEAM: team_offendingcommit
+      TURBO_API: ${{ secrets.TURBO_API || 'https://turborepo-remote-cache-cloudflare.offendingcommit.workers.dev' }}
     steps:
       - uses: actions/checkout@v6
       - uses: pnpm/action-setup@v4
@@ -22,8 +26,6 @@ jobs:
 
       - name: Deploy
         uses: cloudflare/wrangler-action@v3
-        env:
-          TURBO_TOKEN: ${{ secrets.TURBO_TOKEN || 'SECRET' }}
         with:
           accountId: ${{ secrets.CF_ACCOUNT_ID || secrets.CLOUDFLARE_ACCOUNT_ID }}
           apiToken: ${{ secrets.CF_API_TOKEN || secrets.CLOUDFLARE_API_TOKEN }}


### PR DESCRIPTION
## Summary
- define TURBO_TOKEN, TURBO_TEAM, and TURBO_API at deploy job scope
- point Turbo at the self-hosted Cloudflare cache endpoint during the deploy workflow
- keep TURBO_TOKEN available to wrangler-action as the deployed Worker secret

## Validation
- actionlint .github/workflows/deploy.yml